### PR TITLE
feat: add configurable native-only id spoofer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,15 @@ option(ROBLOX_MODLOADER_BUILD_MANAGED_PROJECTS "Build C# projects as part of the
 option(ROBLOX_MODLOADER_USE_CMAKE_CSHARP "Use CMake's native C# project integration on Visual Studio generators" ${RML_DEFAULT_USE_CMAKE_CSHARP})
 option(ROBLOX_MODLOADER_INSTALL "Install RobloxModLoader" OFF)
 option(RML_ENABLE_LUAU "Compile the disabled Luau scripting subsystem (layout-sensitive; VM structs pending re-confirmation via code/tools/dumper)" OFF)
+option(RML_NATIVE_ONLY "Build the reduced native-mod runtime without Luau, .NET, Qt, scheduler, or engine hooks" OFF)
+
+if (RML_NATIVE_ONLY)
+    set(RML_ENABLE_LUAU OFF CACHE BOOL "Compile the Luau scripting subsystem" FORCE)
+    set(ROBLOX_MODLOADER_BUILD_DUMPER OFF CACHE BOOL "Build the Luau structures dumper tool" FORCE)
+    set(ROBLOX_MODLOADER_BUILD_DUMPER_TESTS OFF CACHE BOOL "Build the dumper unit tests" FORCE)
+    set(ROBLOX_MODLOADER_BUILD_MANAGED_PROJECTS OFF CACHE BOOL "Build C# projects" FORCE)
+    set(ROBLOX_MODLOADER_USE_CMAKE_CSHARP OFF CACHE BOOL "Use CMake's C# integration" FORCE)
+endif ()
 
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -56,30 +65,37 @@ set(ROBLOX_MODLOADER_INCLUDE_DIR "code/roblox_modloader/include")
 set(LUAU_SOURCE_DIR "${ROBLOX_MODLOADER_ROOT_DIR}/libs/third_party/luau")
 
 include(cmake/spdlog.cmake)
-include(cmake/zlib.cmake)
 include(cmake/toml.cmake)
-#include(cmake/tracy.cmake)
-include(cmake/luau.cmake)
-include(cmake/json.cmake)
 
-if (RML_PLATFORM_WINDOWS)
-    include(cmake/minhook.cmake)
-    include(cmake/polyhooks.cmake)
-else ()
-    include(cmake/dobby.cmake)
+if (NOT RML_NATIVE_ONLY)
+    include(cmake/zlib.cmake)
+    #include(cmake/tracy.cmake)
+    include(cmake/luau.cmake)
+    include(cmake/json.cmake)
+
+    if (RML_PLATFORM_WINDOWS)
+        include(cmake/minhook.cmake)
+        include(cmake/polyhooks.cmake)
+    else ()
+        include(cmake/dobby.cmake)
+    endif ()
 endif ()
 
-include(cmake/dotnet_hosting.cmake)
+if (NOT RML_NATIVE_ONLY)
+    include(cmake/dotnet_hosting.cmake)
+endif ()
 
 include(cmake/dependencies.cmake)
 
 include(cmake/roblox_add_mod.cmake)
 
-add_subdirectory(libs/third_party)
+if (NOT RML_NATIVE_ONLY)
+    add_subdirectory(libs/third_party)
+endif ()
 
 add_subdirectory(code/roblox_modloader)
 
-if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
+if (CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME AND NOT RML_NATIVE_ONLY)
     add_subdirectory(code/dotnet)
 endif ()
 

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -39,6 +39,10 @@ function(setup_compile_definitions target_name access_level)
 endfunction()
 
 function(setup_luau_dependencies target_name access_level)
+    if (RML_NATIVE_ONLY)
+        return()
+    endif ()
+
     target_link_libraries(${target_name} ${access_level}
             Luau.Compiler
             Luau.Ast
@@ -58,6 +62,19 @@ function(setup_luau_dependencies target_name access_level)
 endfunction()
 
 function(setup_core_dependencies target_name access_level)
+    if (RML_NATIVE_ONLY)
+        target_link_libraries(${target_name} ${access_level}
+                spdlog::spdlog
+                tomlplusplus::tomlplusplus
+        )
+
+        target_include_directories(${target_name} ${access_level}
+                "${spdlog_SOURCE_DIR}"
+                "${tomlplusplus_SOURCE_DIR}/include"
+        )
+        return()
+    endif ()
+
     target_link_libraries(${target_name} ${access_level}
             spdlog::spdlog
             ZLIB::ZLIB

--- a/code/roblox_modloader/CMakeLists.txt
+++ b/code/roblox_modloader/CMakeLists.txt
@@ -131,14 +131,6 @@ target_precompile_headers(roblox_modloader PRIVATE
         "${ROBLOX_MODLOADER_INCLUDE_DIR}/RobloxModLoader/internal/common.hpp"
 )
 
-include(GenerateExportHeader)
-generate_export_header(roblox_modloader
-        EXPORT_FILE_NAME "${ROBLOX_MODLOADER_INCLUDE_DIR}/RobloxModLoader/rml_export.hpp"
-        EXPORT_MACRO_NAME "RML_EXPORT"
-        NO_EXPORT_MACRO_NAME "RML_NO_EXPORT"
-        DEPRECATED_MACRO_NAME "RML_DEPRECATED"
-)
-
 add_library(RobloxModLoader INTERFACE)
 add_library(RobloxModLoader::RobloxModLoader ALIAS RobloxModLoader)
 

--- a/code/roblox_modloader/CMakeLists.txt
+++ b/code/roblox_modloader/CMakeLists.txt
@@ -11,7 +11,26 @@ file(GLOB_RECURSE MODLOADER_SUBDIRS CONFIGURE_DEPENDS
         "${ROBLOX_MODLOADER_SOURCE_DIR}/**/*.hpp"
 )
 
-if (NOT RML_ENABLE_LUAU)
+if (RML_NATIVE_ONLY)
+    set(MODLOADER_SUBDIRS
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/app/application.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/platform/${RML_PLATFORM_ID}/core/entry_point.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/platform/${RML_PLATFORM_ID}/logger/windows_console.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/platform/${RML_PLATFORM_ID}/memory/host_image.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/platform/${RML_PLATFORM_ID}/memory/memory_protection.cpp"
+    )
+
+    file(GLOB_RECURSE RML_NATIVE_RUNTIME_SOURCES CONFIGURE_DEPENDS
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/config/*.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/filesystem/*.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/logger/*.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/memory/*.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/mod/*.cpp"
+            "${ROBLOX_MODLOADER_SOURCE_DIR}/native/*.cpp"
+    )
+    list(FILTER RML_NATIVE_RUNTIME_SOURCES EXCLUDE REGEX "/memory/(module_utils|symbol_resolver)\\.cpp$")
+    list(APPEND MODLOADER_SUBDIRS ${RML_NATIVE_RUNTIME_SOURCES})
+elseif (NOT RML_ENABLE_LUAU)
     list(FILTER MODLOADER_SUBDIRS EXCLUDE REGEX "/luau/")
     list(FILTER MODLOADER_SUBDIRS EXCLUDE REGEX "/hooks/script_context/")
     list(FILTER MODLOADER_SUBDIRS EXCLUDE REGEX "/roblox/jobs/scripting/")
@@ -25,11 +44,13 @@ endforeach ()
 
 list(APPEND MODLOADER_SOURCES ${MODLOADER_SUBDIRS})
 
-file(GLOB_RECURSE MODLOADER_VENDOR_SOURCES CONFIGURE_DEPENDS
-        "${RML_THIRDPARTY_G3D_SRC_DIR}/*.cpp"
-)
+if (NOT RML_NATIVE_ONLY)
+    file(GLOB_RECURSE MODLOADER_VENDOR_SOURCES CONFIGURE_DEPENDS
+            "${RML_THIRDPARTY_G3D_SRC_DIR}/*.cpp"
+    )
 
-list(APPEND MODLOADER_SOURCES ${MODLOADER_VENDOR_SOURCES})
+    list(APPEND MODLOADER_SOURCES ${MODLOADER_VENDOR_SOURCES})
+endif ()
 
 set(RML_VERSION_SCRIPT "${PROJECT_SOURCE_DIR}/cmake/generate-version.cmake")
 set(RML_VERSION_INPUT "${ROBLOX_MODLOADER_SOURCE_DIR}/version.cpp.in")
@@ -65,12 +86,16 @@ add_dependencies(roblox_modloader roblox_modloader_version)
 
 setup_compiler_flags(roblox_modloader)
 setup_compile_definitions(roblox_modloader PRIVATE)
-target_compile_definitions(roblox_modloader PRIVATE RML_ENABLE_LUAU=$<BOOL:${RML_ENABLE_LUAU}>)
+target_compile_definitions(roblox_modloader PRIVATE
+        RML_ENABLE_LUAU=$<BOOL:${RML_ENABLE_LUAU}>
+        RML_NATIVE_ONLY=$<BOOL:${RML_NATIVE_ONLY}>
+)
 setup_core_dependencies(roblox_modloader PRIVATE)
-setup_luau_dependencies(roblox_modloader PRIVATE)
-setup_dotnet_hosting(roblox_modloader PRIVATE)
-
-target_link_libraries(roblox_modloader PRIVATE rml_thirdparty)
+if (NOT RML_NATIVE_ONLY)
+    setup_luau_dependencies(roblox_modloader PRIVATE)
+    setup_dotnet_hosting(roblox_modloader PRIVATE)
+    target_link_libraries(roblox_modloader PRIVATE rml_thirdparty)
+endif ()
 
 if (UNIX AND NOT APPLE)
     target_link_libraries(roblox_modloader PRIVATE dl)
@@ -81,6 +106,15 @@ target_include_directories(roblox_modloader PRIVATE
         "${ROBLOX_MODLOADER_INCLUDE_DIR}"
         "${ROBLOX_MODLOADER_SOURCE_DIR}/platform/${RML_PLATFORM_ID}"
 )
+
+if (RML_NATIVE_ONLY)
+    # RobloxPointers retains its stable public ABI, whose declarations use
+    # Luau types. Headers are sufficient; no Luau target is built or linked.
+    target_include_directories(roblox_modloader PRIVATE
+            "${LUAU_SOURCE_DIR}/VM/include"
+            "${LUAU_SOURCE_DIR}/Common/include"
+    )
+endif ()
 
 set_target_properties(roblox_modloader PROPERTIES
         CXX_STANDARD 23
@@ -111,31 +145,46 @@ add_library(RobloxModLoader::RobloxModLoader ALIAS RobloxModLoader)
 target_include_directories(RobloxModLoader INTERFACE
         "$<BUILD_INTERFACE:${ROBLOX_MODLOADER_INCLUDE_DIR}>"
         "$<INSTALL_INTERFACE:include>"
-        "$<BUILD_INTERFACE:${ROBLOX_MODLOADER_ROOT_DIR}/libs/third_party/g3d/include>"
-        "$<BUILD_INTERFACE:${ROBLOX_MODLOADER_ROOT_DIR}/libs/third_party/bullet/include>"
-        "$<BUILD_INTERFACE:${ROBLOX_MODLOADER_ROOT_DIR}/libs/third_party/rbxg3d/include>"
         "$<BUILD_INTERFACE:${spdlog_SOURCE_DIR}/include>"
         "$<BUILD_INTERFACE:${tomlplusplus_SOURCE_DIR}/include>"
-        "$<BUILD_INTERFACE:${nlohmann_json_SOURCE_DIR}/include>"
-        "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/Compiler/include>"
-        "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/Ast/include>"
-        "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/VM/include>"
-        "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/Common/include>"
 )
+
+if (RML_NATIVE_ONLY)
+    target_include_directories(RobloxModLoader INTERFACE
+            "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/VM/include>"
+            "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/Common/include>"
+    )
+endif ()
 
 target_link_libraries(RobloxModLoader INTERFACE
         spdlog::spdlog
-        nlohmann_json::nlohmann_json
         tomlplusplus::tomlplusplus
-        Luau.Compiler
-        Luau.Ast
-        Luau.VM
-        Luau.VM.Internals
-        Luau.CodeGen
         $<$<TARGET_EXISTS:roblox_modloader>:roblox_modloader>
 )
 
-if (RML_PLATFORM_WINDOWS)
+if (NOT RML_NATIVE_ONLY)
+    target_include_directories(RobloxModLoader INTERFACE
+            "$<BUILD_INTERFACE:${ROBLOX_MODLOADER_ROOT_DIR}/libs/third_party/g3d/include>"
+            "$<BUILD_INTERFACE:${ROBLOX_MODLOADER_ROOT_DIR}/libs/third_party/bullet/include>"
+            "$<BUILD_INTERFACE:${ROBLOX_MODLOADER_ROOT_DIR}/libs/third_party/rbxg3d/include>"
+            "$<BUILD_INTERFACE:${nlohmann_json_SOURCE_DIR}/include>"
+            "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/Compiler/include>"
+            "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/Ast/include>"
+            "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/VM/include>"
+            "$<BUILD_INTERFACE:${LUAU_SOURCE_DIR}/Common/include>"
+    )
+
+    target_link_libraries(RobloxModLoader INTERFACE
+            nlohmann_json::nlohmann_json
+            Luau.Compiler
+            Luau.Ast
+            Luau.VM
+            Luau.VM.Internals
+            Luau.CodeGen
+    )
+endif ()
+
+if (RML_PLATFORM_WINDOWS AND NOT RML_NATIVE_ONLY)
     target_include_directories(RobloxModLoader INTERFACE
             "$<BUILD_INTERFACE:${minhook_SOURCE_DIR}/include>"
             "$<BUILD_INTERFACE:${polyhook2_SOURCE_DIR}>"
@@ -169,7 +218,9 @@ if (MSVC)
     )
 endif ()
 
-setup_dotnet_hosting(RobloxModLoader INTERFACE)
+if (NOT RML_NATIVE_ONLY)
+    setup_dotnet_hosting(RobloxModLoader INTERFACE)
+endif ()
 
 set(RML_LUA_LIBS_DIR "${CMAKE_CURRENT_SOURCE_DIR}/resources/luau")
 

--- a/code/roblox_modloader/include/RobloxModLoader/internal/common.hpp
+++ b/code/roblox_modloader/include/RobloxModLoader/internal/common.hpp
@@ -81,8 +81,10 @@
 
 #include "RobloxModLoader/logger/logger.hpp"
 
-#include <lua.h>
-#include <lualib.h>
+#if !RML_NATIVE_ONLY
+    #include <lua.h>
+    #include <lualib.h>
+#endif
 
 #include "RobloxModLoader/rml_export.hpp"
 

--- a/code/roblox_modloader/include/RobloxModLoader/internal/roblox_pointers.hpp
+++ b/code/roblox_modloader/include/RobloxModLoader/internal/roblox_pointers.hpp
@@ -48,6 +48,7 @@ struct RobloxPointers
 
 	functions::get_string_atom get_string_atom;
 	functions::descriptor_lookup descriptor_lookup;
+	std::uint64_t member_table_offset;
 
 	// Lua Functions
 	functions::luau_execute luau_execute;

--- a/code/roblox_modloader/include/RobloxModLoader/rml_export.hpp
+++ b/code/roblox_modloader/include/RobloxModLoader/rml_export.hpp
@@ -7,22 +7,32 @@
 #  define RML_NO_EXPORT
 #else
 #  ifndef RML_EXPORT
-#    ifdef roblox_modloader_EXPORTS
-        /* We are building this library */
-#      define RML_EXPORT __attribute__((visibility("default")))
+#    if defined(_WIN32)
+#      ifdef roblox_modloader_EXPORTS
+#        define RML_EXPORT __declspec(dllexport)
+#      else
+#        define RML_EXPORT __declspec(dllimport)
+#      endif
 #    else
-        /* We are using this library */
 #      define RML_EXPORT __attribute__((visibility("default")))
 #    endif
 #  endif
 
 #  ifndef RML_NO_EXPORT
-#    define RML_NO_EXPORT __attribute__((visibility("hidden")))
+#    if defined(_WIN32)
+#      define RML_NO_EXPORT
+#    else
+#      define RML_NO_EXPORT __attribute__((visibility("hidden")))
+#    endif
 #  endif
 #endif
 
 #ifndef RML_DEPRECATED
-#  define RML_DEPRECATED __attribute__ ((__deprecated__))
+#  if defined(_WIN32)
+#    define RML_DEPRECATED __declspec(deprecated)
+#  else
+#    define RML_DEPRECATED __attribute__((__deprecated__))
+#  endif
 #endif
 
 #ifndef RML_DEPRECATED_EXPORT

--- a/code/roblox_modloader/include/RobloxModLoader/roblox/reflection/generated/reflection_layout.hpp
+++ b/code/roblox_modloader/include/RobloxModLoader/roblox/reflection/generated/reflection_layout.hpp
@@ -1,0 +1,31 @@
+// Verified against Roblox Studio 0.733.0.7330989 (Windows x64).
+// Keep build-sensitive reflection offsets in the loader SDK instead of mods.
+#pragma once
+
+#include <cstddef>
+
+namespace rml::roblox::reflection::layout
+{
+	inline constexpr const char* studio_version = "0.733.0.7330989";
+
+	inline constexpr std::size_t descriptor_name = 0x8;
+	inline constexpr std::size_t member_owner = 0x30;
+	inline constexpr std::size_t typed_property_get_set = 0x90;
+	inline constexpr std::size_t typed_property_variant_accessor = 0x98;
+
+	// TypedPropertyDescriptor<V>::GetSet has a deleting destructor followed by
+	// is_read_only, is_write_only, get, set, equal_values, and equals_value.
+	inline constexpr std::size_t typed_get_set_vtable_entries = 7;
+	inline constexpr std::size_t typed_get_set_get_vtable_slot = 3;
+
+	// VariantAccessor has a deleting destructor, mutable/const get overloads,
+	// set, data_size, and feature_check.
+	inline constexpr std::size_t typed_variant_accessor_vtable_entries = 6;
+	inline constexpr std::size_t typed_variant_accessor_get_vtable_slot = 1;
+	inline constexpr std::size_t typed_variant_accessor_const_get_vtable_slot = 2;
+
+	// Direct reflected int64 functions use an MSVC member-pointer pair here.
+	inline constexpr std::size_t function_invoke_target = 0x80;
+	inline constexpr std::size_t function_bound_this_delta = 0x88;
+	inline constexpr std::size_t function_descriptor_size = 0x90;
+}

--- a/code/roblox_modloader/src/app/application.cpp
+++ b/code/roblox_modloader/src/app/application.cpp
@@ -2,19 +2,22 @@
 
 #include "RobloxModLoader/internal/common.hpp"
 #include "RobloxModLoader/version.hpp"
-#include "RobloxModLoader/qt/qt_integration.hpp"
 #include "subsystems/config_subsystem.hpp"
 #include "subsystems/logger_subsystem.hpp"
-#include "subsystems/crash_dumper_subsystem.hpp"
 #include "subsystems/event_manager_subsystem.hpp"
-#include "subsystems/qt_integration_subsystem.hpp"
-#include "subsystems/rtti_manager_subsystem.hpp"
 #include "subsystems/pointers_subsystem.hpp"
-#include "subsystems/task_scheduler_subsystem.hpp"
-#include "subsystems/job_manager_subsystem.hpp"
-#include "subsystems/hooking_subsystem.hpp"
-#include "subsystems/script_subsystem_adapter.hpp"
 #include "subsystems/mod_manager_subsystem.hpp"
+
+#if !RML_NATIVE_ONLY
+	#include "RobloxModLoader/qt/qt_integration.hpp"
+	#include "subsystems/crash_dumper_subsystem.hpp"
+	#include "subsystems/hooking_subsystem.hpp"
+	#include "subsystems/job_manager_subsystem.hpp"
+	#include "subsystems/qt_integration_subsystem.hpp"
+	#include "subsystems/rtti_manager_subsystem.hpp"
+	#include "subsystems/script_subsystem_adapter.hpp"
+	#include "subsystems/task_scheduler_subsystem.hpp"
+#endif
 
 RML_LOG_SCOPE("Application");
 
@@ -39,20 +42,34 @@ namespace rml
 		auto event_manager_subsystem = std::make_unique<EventManagerSubsystem>();
 		auto& event_manager_subsystem_ref = *event_manager_subsystem;
 
+#if !RML_NATIVE_ONLY
 		auto task_scheduler_subsystem = std::make_unique<TaskSchedulerSubsystem>();
 		auto& task_scheduler_subsystem_ref = *task_scheduler_subsystem;
+#endif
 
 		m_subsystems.push_back(std::make_unique<ConfigSubsystem>());
 		m_subsystems.push_back(std::make_unique<LoggerSubsystem>());
+
+#if !RML_NATIVE_ONLY
 		m_subsystems.push_back(std::make_unique<CrashDumperSubsystem>());
+#endif
+
 		m_subsystems.push_back(std::move(event_manager_subsystem));
+
+#if !RML_NATIVE_ONLY
 		m_subsystems.push_back(std::make_unique<QtIntegrationSubsystem>());
 		m_subsystems.push_back(std::make_unique<RttiManagerSubsystem>());
+#endif
+
 		m_subsystems.push_back(std::make_unique<PointersSubsystem>());
+
+#if !RML_NATIVE_ONLY
 		m_subsystems.push_back(std::move(task_scheduler_subsystem));
 		m_subsystems.push_back(std::make_unique<JobManagerSubsystem>(task_scheduler_subsystem_ref));
 		m_subsystems.push_back(std::make_unique<HookingSubsystem>());
 		m_subsystems.push_back(std::make_unique<ScriptSubsystemAdapter>());
+#endif
+
 		m_subsystems.push_back(std::make_unique<ModManagerSubsystem>(event_manager_subsystem_ref));
 
 		m_shutdown_complete = false;
@@ -70,6 +87,7 @@ namespace rml
 			RML_INFO("Subsystem initialized: {}", subsystem->name());
 		}
 
+#if !RML_NATIVE_ONLY
 		g_hooking->enable();
 		RML_INFO("Hooking enabled.");
 
@@ -81,6 +99,9 @@ namespace rml
 		{
 			RML_WARN("Qt action hook not installed yet (Qt not resolvable); will retry on demand.");
 		}
+#else
+		RML_INFO("Native-only runtime ready; scheduler, Luau, .NET, Qt, and engine hooks are disabled.");
+#endif
 
 		return {};
 	}
@@ -91,10 +112,12 @@ namespace rml
 
 		while (g_running)
 		{
+#if !RML_NATIVE_ONLY
 			if (const auto qt_integration = qt::QtIntegration::instance(); qt_integration && !qt_integration->is_action_hook_ready())
 			{
 				qt_integration->ensure_action_hook();
 			}
+#endif
 
 			std::this_thread::sleep_for(1s);
 		}

--- a/code/roblox_modloader/src/memory/module.cpp
+++ b/code/roblox_modloader/src/memory/module.cpp
@@ -1,7 +1,10 @@
 #include "RobloxModLoader/memory/module.hpp"
 
 #include "RobloxModLoader/internal/common.hpp"
-#include "RobloxModLoader/memory/symbol_resolver.hpp"
+
+#if !RML_NATIVE_ONLY
+	#include "RobloxModLoader/memory/symbol_resolver.hpp"
+#endif
 
 #if defined(RML_MACOS)
 	#include <mach-o/nlist.h>
@@ -9,6 +12,7 @@
 
 namespace rml::memory
 {
+#if !RML_NATIVE_ONLY
 	static std::pair<std::string_view, std::string_view> split_qualified_name(std::string_view signature)
 	{
 		const auto name = signature.substr(0, signature.find('('));
@@ -53,6 +57,7 @@ namespace rml::memory
 
 		return 0;
 	}
+#endif
 
 	namespace
 	{
@@ -138,6 +143,10 @@ namespace rml::memory
 
 	handle module::find_export(std::string_view signature) const
 	{
+#if RML_NATIVE_ONLY
+		(void)signature;
+		return handle(nullptr);
+#else
 		std::scoped_lock lk(m_mtx);
 
 		if (!m_loaded)
@@ -147,10 +156,14 @@ namespace rml::memory
 
 		const auto it = m_export_index.find(normalize_signature(signature));
 		return it != m_export_index.end() ? handle(it->second) : handle(nullptr);
+#endif
 	}
 
 	void module::build_export_index_locked() const
 	{
+#if RML_NATIVE_ONLY
+		return;
+#else
 		if (m_export_index_built)
 			return;
 
@@ -260,6 +273,7 @@ namespace rml::memory
 
 			insert(name, reinterpret_cast<void*>(static_cast<std::uintptr_t>(symbol.n_value) + slide));
 		}
+#endif
 #endif
 	}
 

--- a/code/roblox_modloader/src/mod/mod_manager.cpp
+++ b/code/roblox_modloader/src/mod/mod_manager.cpp
@@ -1,9 +1,12 @@
 #include "mod_manager.hpp"
 
 #include "RobloxModLoader/internal/common.hpp"
-#include "dotnet/dotnet_mod_loader.hpp"
 #include "native/native_mod_loader.hpp"
 #include "filesystem/directory.hpp"
+
+#if !RML_NATIVE_ONLY
+	#include "dotnet/dotnet_mod_loader.hpp"
+#endif
 
 #include <algorithm>
 #include <cctype>
@@ -21,12 +24,14 @@ namespace rml
 			return std::unexpected(ModManagerError(ModManagerError::Type::DirectoryNotFound, mods_path.error()));
 		}
 
-		const auto runtime_path = filesystem::directory::get_runtime_directory();
-
 		register_loader(std::make_unique<native::NativeModLoader>(event_manager), ModKind::Native);
+
+#if !RML_NATIVE_ONLY
+		const auto runtime_path = filesystem::directory::get_runtime_directory();
 		register_loader(std::make_unique<dotnet::DotnetModLoader>(runtime_path,
 		                     mods_path.value() / mod_kind_folder_name(ModKind::Dotnet)),
 		    ModKind::Dotnet);
+#endif
 
 		for (auto mod_dir : std::filesystem::directory_iterator(mods_path.value()))
 		{

--- a/code/roblox_modloader/src/platform/windows/memory/engine_signatures.hpp
+++ b/code/roblox_modloader/src/platform/windows/memory/engine_signatures.hpp
@@ -7,6 +7,35 @@ namespace rml
 {
 	constexpr auto Pointers::get_roblox_batch()
 	{
+#if RML_NATIVE_ONLY
+		// The native-only runtime resolves only the three reflection primitives
+		// required by idspoofer. Keeping the batch small prevents unrelated,
+		// version-sensitive Luau and scheduler signatures from blocking startup.
+		constexpr auto batch_and_hash = memory::make_batch<
+		    {
+		        "DESCRIPTOR_LOOKUP",
+		        "48 83 EC 18 ? ? ? 4C 8B D9 75",
+		        [](const memory::handle ptr) {
+			        g_pointers->m_roblox_pointers.descriptor_lookup = ptr.as<functions::descriptor_lookup>();
+		        },
+		    },
+		    {
+		        "GET_STRING_ATOM",
+		        "48 89 5C 24 ? 57 48 83 EC 20 48 8B 1D ? ? ? ? 48 8B F9 48 85 DB",
+		        [](const memory::handle ptr) {
+			        g_pointers->m_roblox_pointers.get_string_atom = ptr.as<functions::get_string_atom>();
+		        },
+		    },
+		    {
+		        "MEMBER_TABLE_OFFSET",
+		        "48 8B 4B ? E8 ? ? ? ? 48 8D 8F ? ? ? ? 48 89 44 24 ? 48 8D 54 24 ? E8",
+		        [](const memory::handle ptr) {
+			        g_pointers->m_roblox_pointers.member_table_offset = *ptr.add(12).as<std::uint32_t*>();
+		        },
+		    }>();
+
+		return batch_and_hash;
+#else
 		// clang-format off
 	    constexpr auto batch_and_hash = memory::make_batch<
 	         // Lua Functions
@@ -135,5 +164,6 @@ namespace rml
 		// clang-format on
 
 		return batch_and_hash;
+#endif
 	}
 }

--- a/code/roblox_modloader/src/pointers.cpp
+++ b/code/roblox_modloader/src/pointers.cpp
@@ -18,7 +18,9 @@ namespace rml
 
 		run_batch<roblox_batch_name>(m_roblox_batch, roblox_region);
 
+#if !RML_NATIVE_ONLY
 		m_main_window = platform::acquire_main_window();
+#endif
 	}
 
 	Pointers::~Pointers()

--- a/code/roblox_modloader/src/pointers.hpp
+++ b/code/roblox_modloader/src/pointers.hpp
@@ -33,7 +33,7 @@ namespace rml
 		void* m_main_window{};
 
 	public:
-		RobloxPointers m_roblox_pointers;
+		RobloxPointers m_roblox_pointers{};
 	};
 }
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -144,6 +144,11 @@ endfunction()
 file(GLOB EXAMPLE_DIRS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/*)
 
 foreach (EXAMPLE_DIR ${EXAMPLE_DIRS})
+    if (RML_NATIVE_ONLY AND NOT EXAMPLE_DIR STREQUAL "idspoofer")
+        message(STATUS "Skipping ${EXAMPLE_DIR} (RML_NATIVE_ONLY builds idspoofer only)")
+        continue()
+    endif ()
+
     if (IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE_DIR} AND
     (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE_DIR}/main.cpp OR
             EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/${EXAMPLE_DIR}/CMakeLists.txt))

--- a/examples/idspoofer/README.md
+++ b/examples/idspoofer/README.md
@@ -1,0 +1,50 @@
+# idspoofer
+
+`idspoofer` is a native Roblox ModLoader mod. It can independently spoof:
+
+- every reflected `Player.UserId` getter path used by the engine;
+- `StudioService:GetUserId()`.
+
+The two hooks operate at the Roblox reflection descriptor layer. They do not
+use Luau hooks, script states, the task scheduler, or the DataModel watcher.
+
+## Configuration
+
+Edit the four top-level settings in `mod.toml`:
+
+```toml
+spoof_player = true
+spoof_studio_service = true
+player_user_id = 1585524057
+studio_service_user_id = 1585524057
+```
+
+Both IDs must be positive signed 64-bit integers. Restart Studio after editing
+the file. Each hook is installed only when its boolean is `true`.
+
+## Installation layout
+
+```text
+RobloxStudio version directory/
+  dwmapi.dll
+  roblox_modloader.dll
+  RobloxModLoader/
+    mods/
+      idspoofer/
+        mod.toml
+        native/
+          idspoofer.dll
+```
+
+This build targets Roblox Studio `0.733.0.7330989` on Windows x64.
+
+## Build
+
+```powershell
+cmake -S . -B build-idspoofer -DRML_NATIVE_ONLY=ON
+cmake --build build-idspoofer --config Release --target idspoofer
+```
+
+The `RML_NATIVE_ONLY` configuration builds only the native runtime,
+`dwmapi.dll`, and `idspoofer`; it does not configure the Luau, managed,
+scheduler, Qt, RTTI-scanner, crash-dumper, or general hooking subsystems.

--- a/examples/idspoofer/descriptor_support.cpp
+++ b/examples/idspoofer/descriptor_support.cpp
@@ -4,6 +4,7 @@
 #include <RobloxModLoader/roblox/reflection/generated/reflection_layout.hpp>
 
 #include <algorithm>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 
@@ -225,6 +226,7 @@ namespace idspoofer::detail
 		if (!s_pointers || !name || descriptor_size < member_owner + sizeof(void*))
 			return nullptr;
 
+		const auto scan_started = std::chrono::steady_clock::now();
 		std::size_t name_matches = 0;
 		std::size_t rtti_matches = 0;
 		std::size_t owner_matches = 0;
@@ -280,9 +282,14 @@ namespace idspoofer::detail
 					    (region_begin + alignof(void*) - 1) & ~(alignof(void*) - 1);
 					for (; candidate + descriptor_size <= region_end; candidate += sizeof(void*))
 					{
-						const auto candidate_name = read_memory<std::uintptr_t>(
-						    reinterpret_cast<const void*>(candidate + descriptor_name));
-						if (!candidate_name || *candidate_name != atom)
+						// The entire region was validated once above. Calling VirtualQuery
+						// through read_memory for every 8-byte candidate turns this scan
+						// into millions of system calls on Studio's large .data section.
+						std::uintptr_t candidate_name{};
+						std::memcpy(&candidate_name,
+						    reinterpret_cast<const void*>(candidate + descriptor_name),
+						    sizeof(candidate_name));
+						if (candidate_name != atom)
 							continue;
 
 						++name_matches;
@@ -296,6 +303,10 @@ namespace idspoofer::detail
 						if (owner && lookup_member(*owner, name) == descriptor)
 						{
 							++owner_matches;
+							const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+							    std::chrono::steady_clock::now() - scan_started);
+							RML_INFO("[idspoofer] descriptor '{}' found at {:#x} in {} ms",
+							    name, reinterpret_cast<std::uintptr_t>(descriptor), elapsed.count());
 							return descriptor;
 						}
 					}
@@ -304,8 +315,10 @@ namespace idspoofer::detail
 			}
 		}
 
-		RML_ERROR("[idspoofer] descriptor '{}' not found: name={} RTTI={} owner-roundtrip={}",
-		    name, name_matches, rtti_matches, owner_matches);
+		const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+		    std::chrono::steady_clock::now() - scan_started);
+		RML_ERROR("[idspoofer] descriptor '{}' not found after {} ms: name={} RTTI={} owner-roundtrip={}",
+		    name, elapsed.count(), name_matches, rtti_matches, owner_matches);
 		return nullptr;
 #endif
 	}

--- a/examples/idspoofer/descriptor_support.cpp
+++ b/examples/idspoofer/descriptor_support.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstdint>
 #include <cstring>
+#include <thread>
 
 #if defined(_WIN32)
 	#ifndef NOMINMAX
@@ -230,6 +231,8 @@ namespace idspoofer::detail
 		std::size_t name_matches = 0;
 		std::size_t rtti_matches = 0;
 		std::size_t owner_matches = 0;
+		void* unique_rtti_descriptor = nullptr;
+		void* unique_rtti_owner = nullptr;
 		const std::uintptr_t atom = s_pointers->get_string_atom(name);
 		const auto module = reinterpret_cast<std::uintptr_t>(GetModuleHandleW(nullptr));
 		if (atom == 0 || module == 0
@@ -300,6 +303,16 @@ namespace idspoofer::detail
 						++rtti_matches;
 						const auto owner = read_memory<void*>(
 						    static_cast<std::byte*>(descriptor) + member_owner);
+						if (rtti_matches == 1)
+						{
+							unique_rtti_descriptor = descriptor;
+							unique_rtti_owner = owner.value_or(nullptr);
+						}
+						else
+						{
+							unique_rtti_descriptor = nullptr;
+							unique_rtti_owner = nullptr;
+						}
 						if (owner && lookup_member(*owner, name) == descriptor)
 						{
 							++owner_matches;
@@ -312,6 +325,35 @@ namespace idspoofer::detail
 					}
 				}
 				cursor = region_end;
+			}
+		}
+
+		// The native-only loader intentionally skips the full RTTI-manager scan.
+		// Consequently ModManager can run roughly half a second earlier than it did
+		// in the full loader, while Roblox is still populating ClassDescriptor member
+		// tables. The static descriptor and RTTI already exist at that point, but the
+		// owner hash lookup cannot round-trip yet. Wait for that table instead of
+		// rejecting a descriptor which becomes valid moments later.
+		if (rtti_matches == 1 && unique_rtti_descriptor && unique_rtti_owner
+		    && has_rtti(unique_rtti_owner, ".?AVClassDescriptor@Reflection@RBX@@"))
+		{
+			constexpr auto retry_interval = std::chrono::milliseconds{25};
+			constexpr auto initialization_timeout = std::chrono::seconds{2};
+			RML_INFO("[idspoofer] descriptor '{}' is present at {:#x}; waiting for its owner member table",
+			    name, reinterpret_cast<std::uintptr_t>(unique_rtti_descriptor));
+
+			while (std::chrono::steady_clock::now() - scan_started < initialization_timeout)
+			{
+				std::this_thread::sleep_for(retry_interval);
+				if (lookup_member(unique_rtti_owner, name) != unique_rtti_descriptor)
+					continue;
+
+				++owner_matches;
+				const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+				    std::chrono::steady_clock::now() - scan_started);
+				RML_INFO("[idspoofer] descriptor '{}' owner table became ready after {} ms",
+				    name, elapsed.count());
+				return unique_rtti_descriptor;
 			}
 		}
 

--- a/examples/idspoofer/descriptor_support.cpp
+++ b/examples/idspoofer/descriptor_support.cpp
@@ -1,0 +1,336 @@
+#include "descriptor_support.hpp"
+
+#include <RobloxModLoader/logger/logger.hpp>
+#include <RobloxModLoader/roblox/reflection/generated/reflection_layout.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+
+#if defined(_WIN32)
+	#ifndef NOMINMAX
+		#define NOMINMAX
+	#endif
+	#ifndef WIN32_LEAN_AND_MEAN
+		#define WIN32_LEAN_AND_MEAN
+	#endif
+	#include <windows.h>
+#endif
+
+RML_LOG_SCOPE("IdSpoofer")
+
+namespace idspoofer::detail
+{
+	namespace
+	{
+		const RobloxPointers* s_pointers{};
+
+		struct HashTableHeader
+		{
+			std::uint32_t size;
+			std::uint32_t reserved;
+			const std::uint32_t* control;
+			const void* entries;
+			std::uint32_t mask;
+			std::uint32_t shift;
+		};
+		static_assert(sizeof(HashTableHeader) == 0x20);
+
+#if defined(_WIN32)
+		struct CompleteObjectLocator64
+		{
+			std::uint32_t signature;
+			std::uint32_t offset;
+			std::uint32_t constructor_displacement;
+			std::int32_t type_descriptor_rva;
+			std::int32_t class_descriptor_rva;
+			std::int32_t self_rva;
+		};
+		static_assert(sizeof(CompleteObjectLocator64) == 0x18);
+#endif
+
+		[[nodiscard]] bool validate_member_table(const void* owner) noexcept
+		{
+			if (!s_pointers)
+				return false;
+
+			const auto* table = static_cast<const std::byte*>(owner) + s_pointers->member_table_offset;
+			const auto header = read_memory<HashTableHeader>(table);
+			if (!header || header->size == 0 || header->shift < 4 || header->shift > 16)
+				return false;
+
+			const std::uint32_t control_capacity = 1u << header->shift;
+			const std::uint32_t entry_capacity = header->mask + 1;
+			return entry_capacity != 0 && (entry_capacity & (entry_capacity - 1)) == 0
+			    && entry_capacity <= control_capacity && control_capacity <= entry_capacity * 2
+			    && header->size <= entry_capacity
+			    && memory_has_access(header->control,
+			        static_cast<std::size_t>(control_capacity) * sizeof(std::uint32_t))
+			    && memory_has_access(header->entries,
+			        static_cast<std::size_t>(entry_capacity) * sizeof(void*) * 2);
+		}
+	}
+
+	bool initialize_engine_api() noexcept
+	{
+		if (s_pointers)
+			return true;
+
+		try
+		{
+			s_pointers = get_roblox_pointers();
+		}
+		catch (const std::exception& exception)
+		{
+			RML_ERROR("[idspoofer] could not obtain loader reflection pointers: {}", exception.what());
+			return false;
+		}
+		catch (...)
+		{
+			RML_ERROR("[idspoofer] could not obtain loader reflection pointers");
+			return false;
+		}
+
+		if (!s_pointers || !s_pointers->get_string_atom || !s_pointers->descriptor_lookup)
+		{
+			RML_ERROR("[idspoofer] required reflection functions are unresolved");
+			s_pointers = nullptr;
+			return false;
+		}
+
+		const std::uint64_t offset = s_pointers->member_table_offset;
+		if (offset < 0x40 || offset > 0x1000 || (offset % alignof(void*)) != 0)
+		{
+			RML_ERROR("[idspoofer] invalid ClassDescriptor member-table offset: {:#x}", offset);
+			s_pointers = nullptr;
+			return false;
+		}
+
+		RML_INFO("[idspoofer] reflection API ready (ClassDescriptor member table +{:#x})", offset);
+		return true;
+	}
+
+	const RobloxPointers* engine_pointers() noexcept
+	{
+		return s_pointers;
+	}
+
+	bool memory_has_access(const void* pointer, const std::size_t length, const bool execute) noexcept
+	{
+#if defined(_WIN32)
+		if (!pointer || length == 0)
+			return false;
+
+		const auto start = reinterpret_cast<std::uintptr_t>(pointer);
+		if (start < 0x10000 || start > 0x7FFFFFFFFFFFULL || length > 0x100000 || start + length < start)
+			return false;
+
+		MEMORY_BASIC_INFORMATION information{};
+		if (VirtualQuery(pointer, &information, sizeof(information)) != sizeof(information)
+		    || information.State != MEM_COMMIT
+		    || (information.Protect & (PAGE_GUARD | PAGE_NOACCESS)) != 0)
+			return false;
+
+		const auto region_end = reinterpret_cast<std::uintptr_t>(information.BaseAddress) + information.RegionSize;
+		if (start + length > region_end)
+			return false;
+		if (!execute)
+			return true;
+
+		const DWORD protection = information.Protect & 0xff;
+		return protection == PAGE_EXECUTE || protection == PAGE_EXECUTE_READ
+		    || protection == PAGE_EXECUTE_READWRITE || protection == PAGE_EXECUTE_WRITECOPY;
+#else
+		(void)length;
+		(void)execute;
+		return pointer != nullptr;
+#endif
+	}
+
+	bool is_engine_object(const void* object) noexcept
+	{
+		const auto vtable = read_memory<void* const*>(object);
+		if (!vtable || !memory_has_access(*vtable, sizeof(void*)))
+			return false;
+
+		const auto first = read_memory<void*>(*vtable);
+		return first && memory_has_access(*first, 1, true);
+	}
+
+	std::optional<std::string_view> rtti_name(const void* object) noexcept
+	{
+#if defined(_WIN32)
+		if (!is_engine_object(object))
+			return std::nullopt;
+
+		const auto module = reinterpret_cast<std::uintptr_t>(GetModuleHandleW(nullptr));
+		const auto vtable = read_memory<const void* const*>(object);
+		if (module == 0 || !vtable || !memory_has_access(*vtable - 1, sizeof(void*)))
+			return std::nullopt;
+
+		const auto locator = read_memory<const CompleteObjectLocator64*>((*vtable) - 1);
+		if (!locator || !memory_has_access(*locator, sizeof(CompleteObjectLocator64))
+		    || (*locator)->signature != 1
+		    || module + static_cast<std::uint32_t>((*locator)->self_rva)
+		        != reinterpret_cast<std::uintptr_t>(*locator))
+			return std::nullopt;
+
+		const auto* name = reinterpret_cast<const char*>(
+		    module + static_cast<std::uint32_t>((*locator)->type_descriptor_rva) + sizeof(void*) * 2);
+		for (std::size_t length = 0; length != 1024; ++length)
+		{
+			if (!memory_has_access(name + length, 1))
+				return std::nullopt;
+			if (name[length] == '\0')
+				return std::string_view{name, length};
+		}
+#else
+		(void)object;
+#endif
+		return std::nullopt;
+	}
+
+	bool has_rtti(const void* object, const std::string_view fragment) noexcept
+	{
+		const auto name = rtti_name(object);
+		return name && name->find(fragment) != std::string_view::npos;
+	}
+
+	void* lookup_member(void* owner, const char* name) noexcept
+	{
+		if (!s_pointers || !owner || !name
+		    || !has_rtti(owner, ".?AVClassDescriptor@Reflection@RBX@@")
+		    || !validate_member_table(owner))
+			return nullptr;
+
+		std::uintptr_t atom = s_pointers->get_string_atom(name);
+		if (atom == 0)
+			return nullptr;
+
+		auto* result = s_pointers->descriptor_lookup(
+		    reinterpret_cast<std::uintptr_t>(owner) + s_pointers->member_table_offset, &atom);
+		return result && *result ? reinterpret_cast<void*>(*result) : nullptr;
+	}
+
+	void* discover_descriptor(const char* name, const std::string_view rtti_fragment,
+	    const std::size_t descriptor_size) noexcept
+	{
+#if !defined(_WIN32)
+		(void)name;
+		(void)rtti_fragment;
+		(void)descriptor_size;
+		return nullptr;
+#else
+		using namespace rml::roblox::reflection::layout;
+		if (!s_pointers || !name || descriptor_size < member_owner + sizeof(void*))
+			return nullptr;
+
+		std::size_t name_matches = 0;
+		std::size_t rtti_matches = 0;
+		std::size_t owner_matches = 0;
+		const std::uintptr_t atom = s_pointers->get_string_atom(name);
+		const auto module = reinterpret_cast<std::uintptr_t>(GetModuleHandleW(nullptr));
+		if (atom == 0 || module == 0
+		    || !memory_has_access(reinterpret_cast<void*>(module), sizeof(IMAGE_DOS_HEADER)))
+			return nullptr;
+
+		const auto* dos = reinterpret_cast<const IMAGE_DOS_HEADER*>(module);
+		if (dos->e_magic != IMAGE_DOS_SIGNATURE || dos->e_lfanew <= 0)
+			return nullptr;
+
+		const auto* nt = reinterpret_cast<const IMAGE_NT_HEADERS64*>(
+		    module + static_cast<std::uintptr_t>(dos->e_lfanew));
+		if (!memory_has_access(nt, sizeof(*nt)) || nt->Signature != IMAGE_NT_SIGNATURE)
+			return nullptr;
+
+		const IMAGE_SECTION_HEADER* sections = IMAGE_FIRST_SECTION(nt);
+		if (!memory_has_access(sections,
+		        static_cast<std::size_t>(nt->FileHeader.NumberOfSections) * sizeof(IMAGE_SECTION_HEADER)))
+			return nullptr;
+
+		for (std::uint16_t section_index = 0;
+		     section_index != nt->FileHeader.NumberOfSections; ++section_index)
+		{
+			const IMAGE_SECTION_HEADER& section = sections[section_index];
+			if ((section.Characteristics & IMAGE_SCN_MEM_WRITE) == 0
+			    || section.Misc.VirtualSize < descriptor_size)
+				continue;
+
+			const std::uintptr_t begin = module + section.VirtualAddress;
+			const std::uintptr_t end = begin + section.Misc.VirtualSize;
+			std::uintptr_t cursor = begin;
+			while (cursor < end)
+			{
+				MEMORY_BASIC_INFORMATION information{};
+				if (VirtualQuery(reinterpret_cast<void*>(cursor), &information, sizeof(information))
+				    != sizeof(information))
+					break;
+
+				const auto region_begin = std::max(cursor,
+				    reinterpret_cast<std::uintptr_t>(information.BaseAddress));
+				const auto region_end = std::min(end,
+				    reinterpret_cast<std::uintptr_t>(information.BaseAddress) + information.RegionSize);
+				if (region_end <= region_begin)
+					break;
+
+				if (information.State == MEM_COMMIT
+				    && (information.Protect & (PAGE_GUARD | PAGE_NOACCESS)) == 0)
+				{
+					std::uintptr_t candidate =
+					    (region_begin + alignof(void*) - 1) & ~(alignof(void*) - 1);
+					for (; candidate + descriptor_size <= region_end; candidate += sizeof(void*))
+					{
+						const auto candidate_name = read_memory<std::uintptr_t>(
+						    reinterpret_cast<const void*>(candidate + descriptor_name));
+						if (!candidate_name || *candidate_name != atom)
+							continue;
+
+						++name_matches;
+						auto* descriptor = reinterpret_cast<void*>(candidate);
+						if (!has_rtti(descriptor, rtti_fragment))
+							continue;
+
+						++rtti_matches;
+						const auto owner = read_memory<void*>(
+						    static_cast<std::byte*>(descriptor) + member_owner);
+						if (owner && lookup_member(*owner, name) == descriptor)
+						{
+							++owner_matches;
+							return descriptor;
+						}
+					}
+				}
+				cursor = region_end;
+			}
+		}
+
+		RML_ERROR("[idspoofer] descriptor '{}' not found: name={} RTTI={} owner-roundtrip={}",
+		    name, name_matches, rtti_matches, owner_matches);
+		return nullptr;
+#endif
+	}
+
+	bool atomic_replace_pointer(void* address, void* expected, void* replacement) noexcept
+	{
+#if defined(_WIN32)
+		if (!memory_has_access(address, sizeof(void*)))
+			return false;
+
+		DWORD old_protection = 0;
+		if (VirtualProtect(address, sizeof(void*), PAGE_READWRITE, &old_protection) == 0)
+			return false;
+
+		void* previous = InterlockedCompareExchangePointer(
+		    reinterpret_cast<void* volatile*>(address), replacement, expected);
+		DWORD ignored = 0;
+		(void)VirtualProtect(address, sizeof(void*), old_protection, &ignored);
+		return previous == expected;
+#else
+		auto** slot = static_cast<void**>(address);
+		if (!slot || *slot != expected)
+			return false;
+		*slot = replacement;
+		return true;
+#endif
+	}
+}

--- a/examples/idspoofer/descriptor_support.hpp
+++ b/examples/idspoofer/descriptor_support.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <RobloxModLoader/internal/roblox_pointers.hpp>
+
+#include <cstddef>
+#include <cstring>
+#include <optional>
+#include <string_view>
+
+namespace idspoofer::detail
+{
+	[[nodiscard]] bool initialize_engine_api() noexcept;
+	[[nodiscard]] const RobloxPointers* engine_pointers() noexcept;
+
+	[[nodiscard]] bool memory_has_access(const void* pointer, std::size_t length, bool execute = false) noexcept;
+
+	template<typename T>
+	[[nodiscard]] std::optional<T> read_memory(const void* address) noexcept
+	{
+		if (!memory_has_access(address, sizeof(T)))
+			return std::nullopt;
+
+		T value{};
+		std::memcpy(&value, address, sizeof(value));
+		return value;
+	}
+
+	[[nodiscard]] std::optional<std::string_view> rtti_name(const void* object) noexcept;
+	[[nodiscard]] bool has_rtti(const void* object, std::string_view fragment) noexcept;
+	[[nodiscard]] bool is_engine_object(const void* object) noexcept;
+
+	[[nodiscard]] void* lookup_member(void* owner, const char* name) noexcept;
+	[[nodiscard]] void* discover_descriptor(
+	    const char* name, std::string_view rtti_fragment, std::size_t descriptor_size) noexcept;
+
+	[[nodiscard]] bool atomic_replace_pointer(
+	    void* address, void* expected, void* replacement) noexcept;
+}

--- a/examples/idspoofer/main.cpp
+++ b/examples/idspoofer/main.cpp
@@ -1,0 +1,121 @@
+#include "descriptor_support.hpp"
+#include "player_spoof.hpp"
+#include "studio_service_spoof.hpp"
+
+#include <RobloxModLoader/config/mod_settings.hpp>
+#include <RobloxModLoader/logger/logger.hpp>
+#include <RobloxModLoader/mod/mod_base.hpp>
+
+#include <cstdint>
+#include <memory>
+
+namespace idspoofer
+{
+	constexpr std::int64_t kDefaultUserId = 1585524057LL;
+
+	struct Settings
+	{
+		bool spoof_player{true};
+		bool spoof_studio_service{true};
+		std::int64_t player_user_id{kDefaultUserId};
+		std::int64_t studio_service_user_id{kDefaultUserId};
+	};
+
+	[[nodiscard]] std::int64_t read_user_id(const rml::config::ModSettings& store,
+	    const char* key, const std::int64_t fallback,
+	    const std::shared_ptr<spdlog::logger>& logger)
+	{
+		const std::int64_t value = store.get_int(key, fallback);
+		if (value > 0)
+			return value;
+
+		logger->warn("[idspoofer] '{}' must be a positive 64-bit integer; using {}", key, fallback);
+		return fallback;
+	}
+
+	[[nodiscard]] Settings read_settings(const rml::config::ModSettings& store,
+	    const std::shared_ptr<spdlog::logger>& logger)
+	{
+		Settings settings;
+		settings.spoof_player = store.get_bool("spoof_player", settings.spoof_player);
+		settings.spoof_studio_service =
+		    store.get_bool("spoof_studio_service", settings.spoof_studio_service);
+		settings.player_user_id = read_user_id(
+		    store, "player_user_id", settings.player_user_id, logger);
+		settings.studio_service_user_id = read_user_id(
+		    store, "studio_service_user_id", settings.studio_service_user_id, logger);
+		return settings;
+	}
+}
+
+class IdSpoofer final : public ModBase
+{
+public:
+	IdSpoofer()
+	{
+		name = "idspoofer";
+		version = "1.0.0";
+		author = "rml";
+		description = "Configurable native Player.UserId and StudioService:GetUserId descriptor spoof";
+		m_logger = rml::Logger::get_logger("IdSpoofer");
+	}
+
+	void on_load() override
+	{
+		m_store = std::make_unique<rml::config::ModSettings>(paths().file("mod.toml"));
+		if (!m_store->load())
+		{
+			m_logger->warn("[idspoofer] could not read '{}'; using built-in defaults",
+			    m_store->path().string());
+		}
+
+		const idspoofer::Settings settings = idspoofer::read_settings(*m_store, m_logger);
+		m_logger->info(
+		    "[idspoofer] settings: spoof_player={} player_user_id={} spoof_studio_service={} studio_service_user_id={}",
+		    settings.spoof_player, settings.player_user_id,
+		    settings.spoof_studio_service, settings.studio_service_user_id);
+
+		if (!settings.spoof_player && !settings.spoof_studio_service)
+		{
+			m_logger->info("[idspoofer] both spoof targets are disabled; no descriptor changes made");
+			return;
+		}
+
+		if (!idspoofer::detail::initialize_engine_api())
+		{
+			m_logger->error("[idspoofer] reflection API unavailable; enabled spoofs were not installed");
+			return;
+		}
+
+		if (settings.spoof_player
+		    && !idspoofer::player::install(settings.player_user_id))
+		{
+			m_logger->error("[idspoofer] Player.UserId spoof was not installed");
+		}
+
+		if (settings.spoof_studio_service
+		    && !idspoofer::studio_service::install(settings.studio_service_user_id))
+		{
+			m_logger->error("[idspoofer] StudioService.GetUserId spoof was not installed");
+		}
+	}
+
+	void on_unload() override
+	{
+		idspoofer::studio_service::uninstall();
+		idspoofer::player::uninstall();
+		m_store.reset();
+	}
+
+private:
+	std::shared_ptr<spdlog::logger> m_logger;
+	std::unique_ptr<rml::config::ModSettings> m_store;
+};
+
+extern "C"
+{
+	RML_MOD_ABI_EXPORT ModBase* start_mod() { return new IdSpoofer(); }
+	RML_MOD_ABI_EXPORT void uninstall_mod(const ModBase* mod) { delete mod; }
+}
+
+RML_EXPORT_MOD_ABI_VERSION()

--- a/examples/idspoofer/mod.toml
+++ b/examples/idspoofer/mod.toml
@@ -1,0 +1,12 @@
+name = "idspoofer"
+version = "1.0.0"
+author = "rml"
+description = "Configurable native Player.UserId and StudioService:GetUserId spoof."
+
+# Set either switch to false to leave that engine descriptor untouched.
+spoof_player = true
+spoof_studio_service = true
+
+# Positive signed 64-bit Roblox user IDs. Restart Studio after changing these.
+player_user_id = 1585524057
+studio_service_user_id = 1585524057

--- a/examples/idspoofer/player_spoof.cpp
+++ b/examples/idspoofer/player_spoof.cpp
@@ -1,0 +1,211 @@
+#include "player_spoof.hpp"
+
+#include "descriptor_support.hpp"
+
+#include <RobloxModLoader/internal/engine_abi.hpp>
+#include <RobloxModLoader/logger/logger.hpp>
+#include <RobloxModLoader/roblox/reflection/generated/reflection_layout.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <string_view>
+
+RML_LOG_SCOPE("IdSpoofer")
+
+namespace idspoofer::player
+{
+	namespace
+	{
+		using Getter = std::int64_t(RML_ENGINE_CALL*)(const void* accessor, const void* player);
+
+		constexpr std::string_view kDescriptorRtti =
+		    "PropDescriptor@VPlayer@RBX@@_J@Reflection@RBX@@";
+		constexpr std::string_view kGetterRtti =
+		    "GetSetImpl@P8PlayerProp@RBX@@EBA_JXZP812@EAAX_J@Z";
+		constexpr std::size_t kMaxAccessorVtableEntries =
+		    rml::roblox::reflection::layout::typed_get_set_vtable_entries;
+
+		struct AccessorVtableClone
+		{
+			void* rtti;
+			std::array<void*, kMaxAccessorVtableEntries> slots;
+		};
+
+		struct AccessorHook
+		{
+			void* descriptor{};
+			void* accessor{};
+			void** original_vtable{};
+			Getter original_get{};
+			std::size_t vtable_entries{};
+			std::string label;
+			AccessorVtableClone clone{};
+
+			[[nodiscard]] void** cloned_vtable() noexcept { return clone.slots.data(); }
+		};
+
+		std::mutex s_hook_mutex;
+		std::array<std::unique_ptr<AccessorHook>, 2> s_hooks;
+		std::atomic<std::int64_t> s_user_id{1585524057LL};
+		std::atomic<std::uint64_t> s_reflected_reads{};
+
+		std::int64_t RML_ENGINE_CALL spoof_get(const void*, const void*) noexcept
+		{
+			const std::uint64_t read = s_reflected_reads.fetch_add(1, std::memory_order_relaxed) + 1;
+			const std::int64_t user_id = s_user_id.load(std::memory_order_relaxed);
+			if (read == 1)
+				RML_INFO("[idspoofer] first reflected Player.UserId read -> {}", user_id);
+			return user_id;
+		}
+	}
+
+	bool install(const std::int64_t user_id) noexcept
+	{
+		using namespace rml::roblox::reflection::layout;
+
+		std::lock_guard lock(s_hook_mutex);
+		s_user_id.store(user_id, std::memory_order_relaxed);
+		if (s_hooks[0])
+		{
+			RML_INFO("[idspoofer] Player.UserId spoof updated -> {}", user_id);
+			return true;
+		}
+
+		void* descriptor = detail::discover_descriptor(
+		    "UserId", kDescriptorRtti, typed_property_variant_accessor + sizeof(void*));
+		if (!descriptor)
+		{
+			RML_ERROR("[idspoofer] Player.UserId descriptor validation failed; player spoof disabled");
+			return false;
+		}
+
+		const auto get_set = detail::read_memory<void*>(
+		    static_cast<std::byte*>(descriptor) + typed_property_get_set);
+		if (!get_set || !detail::has_rtti(*get_set, kGetterRtti))
+		{
+			RML_ERROR("[idspoofer] Player.UserId GetSet accessor failed RTTI validation; player spoof disabled");
+			return false;
+		}
+
+		const auto variant_accessor = detail::read_memory<void*>(
+		    static_cast<std::byte*>(descriptor) + typed_property_variant_accessor);
+		if (!variant_accessor || (*variant_accessor && !detail::is_engine_object(*variant_accessor)))
+		{
+			RML_ERROR("[idspoofer] Player.UserId VariantAccessor failed validation; player spoof disabled");
+			return false;
+		}
+
+		auto make_replacement = [descriptor](void* accessor, const std::size_t entries,
+		                            const std::array<std::size_t, 2>& getter_slots,
+		                            const std::size_t getter_slot_count, std::string label)
+		{
+			const auto original_vtable = detail::read_memory<void**>(accessor);
+			if (!original_vtable || entries > kMaxAccessorVtableEntries
+			    || !detail::memory_has_access(*original_vtable - 1,
+			        sizeof(void*) * (entries + 1)))
+				return std::unique_ptr<AccessorHook>{};
+
+			for (std::size_t slot = 0; slot != entries; ++slot)
+			{
+				if (!detail::memory_has_access((*original_vtable)[slot], 1, true))
+					return std::unique_ptr<AccessorHook>{};
+			}
+
+			auto replacement = std::make_unique<AccessorHook>();
+			replacement->descriptor = descriptor;
+			replacement->accessor = accessor;
+			replacement->original_vtable = *original_vtable;
+			replacement->original_get = reinterpret_cast<Getter>((*original_vtable)[getter_slots[0]]);
+			replacement->vtable_entries = entries;
+			replacement->label = std::move(label);
+			replacement->clone.rtti = (*original_vtable)[-1];
+			std::copy_n(*original_vtable, entries, replacement->clone.slots.begin());
+			for (std::size_t index = 0; index != getter_slot_count; ++index)
+				replacement->clone.slots[getter_slots[index]] = reinterpret_cast<void*>(&spoof_get);
+			return replacement;
+		};
+
+		auto get_set_replacement = make_replacement(*get_set, typed_get_set_vtable_entries,
+		    {typed_get_set_get_vtable_slot, 0}, 1, "GetSet");
+		std::unique_ptr<AccessorHook> variant_replacement;
+		if (*variant_accessor)
+		{
+			variant_replacement = make_replacement(*variant_accessor,
+			    typed_variant_accessor_vtable_entries,
+			    {typed_variant_accessor_get_vtable_slot,
+			        typed_variant_accessor_const_get_vtable_slot},
+			    2, "VariantAccessor");
+		}
+
+		if (!get_set_replacement || (*variant_accessor && !variant_replacement))
+		{
+			RML_ERROR("[idspoofer] a Player.UserId accessor vtable failed validation; player spoof disabled");
+			return false;
+		}
+
+		s_hooks[0] = std::move(get_set_replacement);
+		if (!detail::atomic_replace_pointer(
+		        s_hooks[0]->accessor, s_hooks[0]->original_vtable, s_hooks[0]->cloned_vtable()))
+		{
+			s_hooks[0].reset();
+			RML_ERROR("[idspoofer] Player.UserId GetSet vtable swap failed; player spoof disabled");
+			return false;
+		}
+
+		if (variant_replacement)
+		{
+			s_hooks[1] = std::move(variant_replacement);
+			if (!detail::atomic_replace_pointer(
+			        s_hooks[1]->accessor, s_hooks[1]->original_vtable, s_hooks[1]->cloned_vtable()))
+			{
+				(void)detail::atomic_replace_pointer(
+				    s_hooks[0]->accessor, s_hooks[0]->cloned_vtable(), s_hooks[0]->original_vtable);
+				s_hooks[0].reset();
+				s_hooks[1].reset();
+				RML_ERROR("[idspoofer] Player.UserId VariantAccessor swap failed; restored GetSet");
+				return false;
+			}
+		}
+
+		RML_INFO("[idspoofer] Player.UserId descriptor={:#x} GetSet={:#x} VariantAccessor={:#x} -> {}",
+		    reinterpret_cast<std::uintptr_t>(descriptor),
+		    reinterpret_cast<std::uintptr_t>(s_hooks[0]->accessor),
+		    reinterpret_cast<std::uintptr_t>(s_hooks[1] ? s_hooks[1]->accessor : nullptr),
+		    user_id);
+		return true;
+	}
+
+	void uninstall() noexcept
+	{
+		std::lock_guard lock(s_hook_mutex);
+		bool restored_any = false;
+		for (auto& installed : s_hooks)
+		{
+			if (!installed)
+				continue;
+
+			if (!detail::atomic_replace_pointer(
+			        installed->accessor, installed->cloned_vtable(), installed->original_vtable))
+			{
+				RML_WARN("[idspoofer] Player.UserId {} vtable changed externally; not restoring",
+				    installed->label);
+			}
+			else
+			{
+				restored_any = true;
+			}
+			installed.reset();
+		}
+
+		if (restored_any)
+		{
+			RML_INFO("[idspoofer] restored Player.UserId accessors after {} reflected read(s)",
+			    s_reflected_reads.load(std::memory_order_relaxed));
+		}
+	}
+}

--- a/examples/idspoofer/player_spoof.hpp
+++ b/examples/idspoofer/player_spoof.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+namespace idspoofer::player
+{
+	[[nodiscard]] bool install(std::int64_t user_id) noexcept;
+	void uninstall() noexcept;
+}

--- a/examples/idspoofer/studio_service_spoof.cpp
+++ b/examples/idspoofer/studio_service_spoof.cpp
@@ -1,0 +1,118 @@
+#include "studio_service_spoof.hpp"
+
+#include "descriptor_support.hpp"
+
+#include <RobloxModLoader/internal/engine_abi.hpp>
+#include <RobloxModLoader/logger/logger.hpp>
+#include <RobloxModLoader/roblox/reflection/generated/reflection_layout.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <mutex>
+#include <optional>
+#include <string_view>
+
+RML_LOG_SCOPE("IdSpoofer")
+
+namespace idspoofer::studio_service
+{
+	namespace
+	{
+		constexpr std::string_view kDescriptorRtti =
+		    "BoundFuncDesc@VRESTRICTED_StudioService@RBX@@$$A6A_JXZ";
+
+		struct InstalledHook
+		{
+			void* descriptor{};
+			void** target_slot{};
+			void* original_target{};
+			std::int32_t bound_this_delta{};
+		};
+
+		std::mutex s_hook_mutex;
+		std::optional<InstalledHook> s_hook;
+		std::atomic<std::int64_t> s_user_id{1585524057LL};
+		std::atomic<std::uint64_t> s_reflected_calls{};
+
+		std::int64_t RML_ENGINE_CALL spoof_get_user_id(const void*) noexcept
+		{
+			const std::uint64_t call = s_reflected_calls.fetch_add(1, std::memory_order_relaxed) + 1;
+			const std::int64_t user_id = s_user_id.load(std::memory_order_relaxed);
+			if (call == 1)
+				RML_INFO("[idspoofer] first reflected StudioService:GetUserId() call -> {}", user_id);
+			return user_id;
+		}
+	}
+
+	bool install(const std::int64_t user_id) noexcept
+	{
+		using namespace rml::roblox::reflection::layout;
+
+		std::lock_guard lock(s_hook_mutex);
+		s_user_id.store(user_id, std::memory_order_relaxed);
+		if (s_hook)
+		{
+			RML_INFO("[idspoofer] StudioService.GetUserId spoof updated -> {}", user_id);
+			return true;
+		}
+
+		void* descriptor = detail::discover_descriptor(
+		    "GetUserId", kDescriptorRtti, function_descriptor_size);
+		if (!descriptor)
+		{
+			RML_ERROR("[idspoofer] StudioService.GetUserId descriptor validation failed; StudioService spoof disabled");
+			return false;
+		}
+
+		auto** target_slot = reinterpret_cast<void**>(
+		    static_cast<std::byte*>(descriptor) + function_invoke_target);
+		const auto original_target = detail::read_memory<void*>(target_slot);
+		const auto bound_this_delta = detail::read_memory<std::int32_t>(
+		    static_cast<std::byte*>(descriptor) + function_bound_this_delta);
+		if (!original_target || !detail::memory_has_access(*original_target, 1, true)
+		    || !bound_this_delta)
+		{
+			RML_ERROR("[idspoofer] StudioService.GetUserId member-pointer pair failed validation; StudioService spoof disabled");
+			return false;
+		}
+
+		if (!detail::atomic_replace_pointer(
+		        target_slot, *original_target, reinterpret_cast<void*>(&spoof_get_user_id)))
+		{
+			RML_ERROR("[idspoofer] StudioService.GetUserId target swap failed; StudioService spoof disabled");
+			return false;
+		}
+
+		s_hook = InstalledHook{
+		    .descriptor = descriptor,
+		    .target_slot = target_slot,
+		    .original_target = *original_target,
+		    .bound_this_delta = *bound_this_delta,
+		};
+
+		RML_INFO("[idspoofer] StudioService.GetUserId descriptor={:#x} target={:#x} this-delta={} -> {}",
+		    reinterpret_cast<std::uintptr_t>(descriptor),
+		    reinterpret_cast<std::uintptr_t>(*original_target),
+		    *bound_this_delta, user_id);
+		return true;
+	}
+
+	void uninstall() noexcept
+	{
+		std::lock_guard lock(s_hook_mutex);
+		if (!s_hook)
+			return;
+
+		if (!detail::atomic_replace_pointer(s_hook->target_slot,
+		        reinterpret_cast<void*>(&spoof_get_user_id), s_hook->original_target))
+		{
+			RML_WARN("[idspoofer] StudioService.GetUserId target changed externally; not restoring");
+		}
+		else
+		{
+			RML_INFO("[idspoofer] restored StudioService.GetUserId after {} reflected call(s)",
+			    s_reflected_calls.load(std::memory_order_relaxed));
+		}
+		s_hook.reset();
+	}
+}

--- a/examples/idspoofer/studio_service_spoof.hpp
+++ b/examples/idspoofer/studio_service_spoof.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <cstdint>
+
+namespace idspoofer::studio_service
+{
+	[[nodiscard]] bool install(std::int64_t user_id) noexcept;
+	void uninstall() noexcept;
+}


### PR DESCRIPTION
Tweaked the roblox mod_loader to allow building shim versions that only support native loading (for easily distribution native plugins for example)

And added an example of an id spoofer plugin !